### PR TITLE
Fix table name to use sql_prefix from config file

### DIFF
--- a/record.php
+++ b/record.php
@@ -32,7 +32,7 @@
 		if (array_key_exists('p', $data)) $pressure = $data['p'];
 		if (array_key_exists('conn', $data)) $connection = $data['conn'];
 
-        $sql = "INSERT INTO log_locations (accuracy, altitude, battery_level, heading, description, event, latitude, longitude, radius, trig, tracker_id, epoch, vertical_accuracy, velocity, pressure, connection) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
+        $sql = "INSERT INTO " . $_config['sql_prefix'] . "locations (accuracy, altitude, battery_level, heading, description, event, latitude, longitude, radius, trig, tracker_id, epoch, vertical_accuracy, velocity, pressure, connection) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)";
         $stmt = $mysqli->prepare($sql);
         # bind parameters (s = string, i = integer, d = double,  b = blob)
         $stmt->bind_param('iiiissddisssiids', $accuracy, $altitude, $battery_level, $heading, $description, $event, $latitude, $longitude, $radius, $trig, $tracker_id, $epoch, $vertical_accuracy, $velocity, $pressure, $connection);


### PR DESCRIPTION
was originally defaulting to log_locations rather than using the prefix from the config file