### PR TITLE
Fix empty tid_markers when trying to delete a marker, or changing trackerID

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -14,7 +14,7 @@ var i;
 var map_drawn = false;
 var show_markers;
 var mymap;
-var tid_markers; // markers collected from json
+var tid_markers = []; // markers collected from json
 var my_marker;
 var my_markers = [];
 var my_latlngs = [];
@@ -371,7 +371,6 @@ function drawMap(_tid_markers){
         nb_markers=0; // global markers counter
         trackerIDs = Object.keys(_tid_markers);
 
-        tid_markers = []; // markers collected from json
         my_markers = [];
         my_latlngs = [];
         polylines = [];


### PR DESCRIPTION
There are two issues that seem to have the same cause:
- when trying to delete a marker, there is an error and the marker is not deleted (first screenshot)
- when changing the trackerID, an error is displayed even if there is data (second screenshot)

<img width="527" alt="Capture d’écran 2022-10-14 à 16 54 12" src="https://user-images.githubusercontent.com/265349/195877610-ba76afcf-3be3-46d1-a47e-9107a1e6a571.png">

<img width="469" alt="Capture d’écran 2022-10-14 à 16 54 44" src="https://user-images.githubusercontent.com/265349/195877627-5653c58c-33c6-45ab-b3e9-c4fc1054c20d.png">

The two issues have the same source: the `tid_markers` array is empty.

This PR fixes the issue by removing the line where `tid_markers` is emptied in `drawMap`. In case this line was to initialize the array, that initialization is now done at the very top.