### PR TITLE
Remove double JSON encoding of markers

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -674,7 +674,7 @@ function getMarkers(){
         {
             if(data.status){
 
-                jsonMarkers = JSON.parse(data.markers);
+                jsonMarkers = data.markers;
 
                 if(handleMarkersData(jsonMarkers)){ $('#mapid').css('filter','blur(0px)'); }
 

--- a/rpc.php
+++ b/rpc.php
@@ -57,7 +57,7 @@ if (array_key_exists('action', $_REQUEST)) {
             http_response_code(500);
         } else {
             $response['status'] = true;
-            $response['markers'] = json_encode($markers);
+            $response['markers'] = $markers;
         }
 
 


### PR DESCRIPTION
I noticed that markers are JSON encoded twice by `rpc.php`. This looks unnecessary and makes it harder to consume the data from the API.
This PR proposes to remove the extra JSON encoding of markers.
I don't have all the context for why this is the case. So feel free to ignore if there is a use case for JSON encoding markers twice.